### PR TITLE
stops generate puzzle from going on infinitely

### DIFF
--- a/src/lib/sudoku.ts
+++ b/src/lib/sudoku.ts
@@ -23,6 +23,8 @@ const MODES: ModesType = {
 
 const DEFAULT_MODE = "9"
 
+let solveTimeout = new Date()
+
 export default class Sudoku {
   grid: Array<number[]>
   mode: ModeType
@@ -73,7 +75,7 @@ export default class Sudoku {
         baseNumbers--
       }
     }
-
+    solveTimeout = new Date()
     if (!this.solve()) {
       return this.generate()
     }
@@ -221,6 +223,9 @@ export default class Sudoku {
     var allowedNumbers = this.allowedNumbers(x, y)
 
     while (allowedNumbers.length > 0) {
+      if (new Date().getTime() - solveTimeout.getTime() > 50) {
+        return false
+      }
       let value = allowedNumbers.shift() as number
       this.set(x, y, value)
 


### PR DESCRIPTION
There are times that the regenerate game button would freeze the app because it would attempt to solve an unsolvable puzzle forever. This PR means that when generating a puzzle, it stops attempting to solve it after 50ms and generates a new puzzle instead. 